### PR TITLE
Fix the resource name for underlined characters color

### DIFF
--- a/color-themes
+++ b/color-themes
@@ -104,7 +104,7 @@ sub escape_seq {
         'italicColor'      => '704',
         'tintColor'        => '705',
         'boldColor'        => '706',
-        'underlinedColor'  => '707',
+        'colorUL'          => '707',
         'borderColor'      => '708',
         'font'             => '710',
         'boldFont'         => '711',


### PR DESCRIPTION
According to urxvt(7), 707 changes the "colour of underlined
characters", the resource for that is colorUL (urxvt(1): "Use the
specified colour to display underlined characters when the foreground
colour is the default.")
